### PR TITLE
New Board :  Rock 4c+ (rock-4c-plus)

### DIFF
--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-storage-layout-base_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-storage-layout-base_%.bbappend
@@ -29,8 +29,8 @@ do_install:append:tegra194() {
     # prevents the Mender data partition to use remaining space.
     sed -i -e 's#<start_location> 0x708400000 </start_location>##g' \
            -e 's#<start_location> 0x710800000 </start_location>##g' \
-		   ${D}${datadir}/tegraflash/${PARTITION_LAYOUT_TEMPLATE}
+		   ${D}${datadir}/l4t-storage-layout/${PARTITION_LAYOUT_TEMPLATE}
     sed -i -e 's#<start_location> 0x708400000 </start_location>##g' \
            -e 's#<start_location> 0x710800000 </start_location>##g' \
-		   ${D}${datadir}/tegraflash/${PARTITION_LAYOUT_EXTERNAL}
+		   ${D}${datadir}/l4t-storage-layout/${PARTITION_LAYOUT_EXTERNAL}
 }


### PR DESCRIPTION
Raspberry Pi 4 Form Factor board 

https://radxa.com/products/rock4/4cp/

### Spec summary
Rockchip RK3399‑T
Dual-Core ARM® Cortex-A72 @ 1.5GHz and Quad-Core ARM® Cortex-A53 @ 1.0GHz
 4GB LPDDR4
microSD or eMMC
2x Micro HDMI ports support displays up to 4Kp60 resolution and 2Kp60
1x Gigabit Ethernet 
1x USB3 OTG/HOST port
1x USB3 HOST port
2x USB2 HOST ports
Raspberry Pi compatible GPIO Header

## Notes
https://wiki.radxa.com/Rock4/dev
Custom sdcard layout needed:
[radxa uboot docs ](https://wiki.radxa.com/Rockpi4/dev/u-boot)
Ethernet kernel module:
CONFIG_DWMAC_ROCKCHIP










